### PR TITLE
Add macos support

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -36,7 +36,12 @@ do
   	--command="\\timing" \
 	--command="\\copy (select * from ppm) to './${outputdir}/${scenename}.ppm' csv"
 
-  xdg-open ./${outputdir}/${scenename}.ppm
+  if [ "$(uname)" == "Darwin" ]; then
+    open ./${outputdir}/${scenename}.ppm
+  else
+    xdg-open ./${outputdir}/${scenename}.ppm
+  fi
+  
   convert ./${outputdir}/${scenename}.ppm ./${outputdir}/${scenename}.png
 
 done < ./${outputdir}/${scenelist}


### PR DESCRIPTION
Add a system check, if the `uname` is `Darwin` use the `open` command in place of `xdg-open`.

Tested with a run. I don't have access to Windows to add support.

No sweat if you want to reject this! 