### PR TITLE
Add macos support

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -36,7 +36,12 @@ do
   	--command="\\timing" \
 	--command="\\copy (select * from ppm) to './${outputdir}/${scenename}.ppm' csv"
 
-  xdg-open ./${outputdir}/${scenename}.ppm
+  if [ "$(uname)" == "Darwin" ]; then
+    open ./${outputdir}/${scenename}.ppm
+  else
+    xdg-open ./${outputdir}/${scenename}.ppm
+  fi
+  
   convert ./${outputdir}/${scenename}.ppm ./${outputdir}/${scenename}.png
 
 done < ./${outputdir}/${scenelist}


### PR DESCRIPTION
Adds a system check. If the `uname` is `Darwin` (macos), replace the `xdg-open` command with `open`. Tested with a run. No other changes needed on macos; the rest of the docs and code will work if the basic requirements are met. Tested on 11.6.5. Don't have access to Windows to add and test support for it.

Second PR - first had a commit chain issue that is fixed in this one.

No sweat if you don't want to merge this or anything! Thought this was really neat and one small change made it work on my computer.